### PR TITLE
Add sif file python

### DIFF
--- a/code/python/ecat2nii.py
+++ b/code/python/ecat2nii.py
@@ -1,3 +1,5 @@
+import datetime
+
 import nibabel
 import numpy
 import pathlib
@@ -22,6 +24,7 @@ def ecat2nii(ecat_main_header=None,
         nifti_file = nifti_file
     # collect the output folder from the nifti path will use for .sif files
     output_folder = pathlib.Path(nifti_file).parent
+    nifti_file_w_out_extension = os.path.splitext(str(pathlib.Path(nifti_file).name))[0]
 
     # if already read nifti file skip re-reading
     if ecat_main_header is None and ecat_subheaders is None and ecat_pixel_data is None and ecat_file:
@@ -202,6 +205,16 @@ def ecat2nii(ecat_main_header=None,
 
     # write out timing file
     if sif_out:
-        pass
+        with open(os.path.join(output_folder, nifti_file_w_out_extension + '.sif'), 'w') as siffile:
+            scantime = datetime.datetime.fromtimestamp(main_header['SCAN_START_TIME'])
+            scantime = scantime.astimezone().isoformat()
+            siffile.write(f"{scantime} {len(start)} 4 1\n")
+            for index in range(len(start)):
+                start_i = round(start[index])
+                start_i_plus_delta_i = start_i + delta[index]
+                prompt = round(prompts[index])
+                random = round(randoms[index])
+                output_string = f"{start_i} {start_i_plus_delta_i} {prompt} {random}\n"
+                siffile.write(output_string)
 
     return img_nii

--- a/code/python/ecat2nii.py
+++ b/code/python/ecat2nii.py
@@ -82,13 +82,13 @@ def ecat2nii(ecat_main_header=None,
         # save out our slice of data before flip to a text file to compare w/ matlab data
         img_temp[:, :, :, index] = numpy.flip(numpy.flip(numpy.flip(
             data[:, :, :, index].astype(numpy.dtype('>f4')) * sub_headers[index]['SCALE_FACTOR'], 1), 2), 0)
-        start.append(sub_headers[index]['FRAME_START_TIME'] * 60)  # scale to per minute
-        delta.append(sub_headers[index]['FRAME_DURATION'] * 60)  # scale to per minute
+        start.append(sub_headers[index]['FRAME_START_TIME'] * 0.001)  # scale to per minute
+        delta.append(sub_headers[index]['FRAME_DURATION'] * 0.001)  # scale to per minute
 
         if main_header.get('SW_VERSION', 0) >= 73:
             # scale both to per minute
-            prompts.append(sub_headers[index]['PROMPT_RATE'] * sub_headers[index]['FRAME_DURATION'] * 60)
-            randoms.append(sub_headers[index]['RANDOM_RATE'] * sub_headers[index]['FRAME_DURATION'] * 60)
+            prompts.append(sub_headers[index]['PROMPT_RATE'] * sub_headers[index]['FRAME_DURATION'] * 0.001)
+            randoms.append(sub_headers[index]['RANDOM_RATE'] * sub_headers[index]['FRAME_DURATION'] * 0.001)
         else:
             # this field is not available in ecat 7.2
             prompts.append(0)
@@ -209,9 +209,9 @@ def ecat2nii(ecat_main_header=None,
             scantime = datetime.datetime.fromtimestamp(main_header['SCAN_START_TIME'])
             scantime = scantime.astimezone().isoformat()
             siffile.write(f"{scantime} {len(start)} 4 1\n")
-            for index in range(len(start)):
+            for index in reversed(range(len(start))):
                 start_i = round(start[index])
-                start_i_plus_delta_i = start_i + delta[index]
+                start_i_plus_delta_i = start_i + round(delta[index])
                 prompt = round(prompts[index])
                 random = round(randoms[index])
                 output_string = f"{start_i} {start_i_plus_delta_i} {prompt} {random}\n"

--- a/code/python/tests/test_nifti_write.py
+++ b/code/python/tests/test_nifti_write.py
@@ -39,7 +39,7 @@ if __name__ == '__main__':
 
     # testing how much this image gets mangled w/ nifti conversion
     # write nifti and save binary of nibabel.Nifti1 object
-    read_from_ecat_but_not_written = ecat2nii(ecat_file=ecat_path, nifti_file=nifti_path, save_binary=True)
+    read_from_ecat_but_not_written = ecat2nii(ecat_file=ecat_path, nifti_file=nifti_path, save_binary=True, sif_out=True)
 
     # load pickled object why not?
     pickled_nifti = pickle.load(open(nifti_path + ".pickle", 'rb'))


### PR DESCRIPTION
This makes the sif file, just like the matlab version. Note, the python ecat_read does no conversion on any values read in from an ecat. Thus the scaling in ecat2nii.py and ecat2nii.m are different to account for this fact w/ respect to frame start and delta times.